### PR TITLE
Search fields of BaseType and search all fields marked UnityEngine.SerializeField.

### DIFF
--- a/Editor/AssetUsageDetector.cs
+++ b/Editor/AssetUsageDetector.cs
@@ -587,8 +587,8 @@ namespace AssetUsageDetectorNamespace
 			if( fieldType.IsDerivedFrom( typeof( Object ) ) )
 				return true;
 
-            if( Attribute.IsDefined( fieldInfo, typeof( UnityEngine.SerializeField ) ) )
-                return true;
+			if( Attribute.IsDefined( fieldInfo, typeof( UnityEngine.SerializeField ) ) )
+				return true;
 
 			if( fieldType.IsArray )
 			{
@@ -1874,21 +1874,21 @@ namespace AssetUsageDetectorNamespace
 			}
 		}
 
-        // Get all fields of a type and its base types recursively
-        private static List<FieldInfo> GetAllFields(Type type, BindingFlags flags)
-        {
-            if (type == null)
-                return new List<FieldInfo>();
+		// Get all fields of a type and its base types recursively
+		private static List<FieldInfo> GetAllFields(Type type, BindingFlags flags)
+		{
+			if (type == null)
+				return new List<FieldInfo>();
 
-            var list = GetAllFields( type.BaseType, flags );
-            
-            // In order to avoid duplicates, force BindingFlags.DeclaredOnly
-            list.AddRange( type.GetFields( flags | BindingFlags.DeclaredOnly ) );
-            return list;
-        }
+			var list = GetAllFields( type.BaseType, flags );
+			
+			// In order to avoid duplicates, force BindingFlags.DeclaredOnly
+			list.AddRange( type.GetFields( flags | BindingFlags.DeclaredOnly ) );
+			return list;
+		}
 
-        // Get filtered variables for a type
-        private VariableGetterHolder[] GetFilteredVariablesForType( Type type )
+		// Get filtered variables for a type
+		private VariableGetterHolder[] GetFilteredVariablesForType( Type type )
 		{
 			VariableGetterHolder[] result;
 			if( typeToVariables.TryGetValue( type, out result ) )
@@ -1905,7 +1905,7 @@ namespace AssetUsageDetectorNamespace
 			// Filter the fields
 			if( fieldModifiers != BindingFlags.Instance )
 			{
-                List<FieldInfo> fields = GetAllFields( type, fieldModifiers );
+				List<FieldInfo> fields = GetAllFields( type, fieldModifiers );
 				for( int i = 0; i < fields.Count; i++ )
 				{
 					// Skip obsolete fields
@@ -2047,7 +2047,7 @@ namespace AssetUsageDetectorNamespace
 					searchedTypesStack.Push( type );
 
 					HashSet<Type> searchedVariableTypes = new HashSet<Type>();
-                    List<FieldInfo> fields = GetAllFields( type, fieldModifiers);
+					List<FieldInfo> fields = GetAllFields( type, fieldModifiers);
 					for( int i = 0; i < fields.Count; i++ )
 					{
 						Type fieldType = fields[i].FieldType;

--- a/Editor/AssetUsageDetector.cs
+++ b/Editor/AssetUsageDetector.cs
@@ -587,6 +587,9 @@ namespace AssetUsageDetectorNamespace
 			if( fieldType.IsDerivedFrom( typeof( Object ) ) )
 				return true;
 
+            if( Attribute.IsDefined( fieldInfo, typeof( UnityEngine.SerializeField ) ) )
+                return true;
+
 			if( fieldType.IsArray )
 			{
 				if( fieldType.GetArrayRank() != 1 )
@@ -602,8 +605,7 @@ namespace AssetUsageDetectorNamespace
 				fieldType = fieldType.GetGenericArguments()[0];
 			}
 
-			if( fieldType.IsGenericType || fieldInfo.IsInitOnly ||
-			  ( ( !fieldInfo.IsPublic || fieldInfo.IsNotSerialized ) && !Attribute.IsDefined( fieldInfo, typeof( SerializeField ) ) ) )
+			if( fieldType.IsGenericType || fieldInfo.IsInitOnly || !fieldInfo.IsPublic || fieldInfo.IsNotSerialized )
 				return false;
 
 			if( Attribute.IsDefined( fieldType, typeof( SerializableAttribute ), false ) )

--- a/Editor/AssetUsageDetector.cs
+++ b/Editor/AssetUsageDetector.cs
@@ -1872,8 +1872,21 @@ namespace AssetUsageDetectorNamespace
 			}
 		}
 
-		// Get filtered variables for a type
-		private VariableGetterHolder[] GetFilteredVariablesForType( Type type )
+        // Get all fields of a type and its base types recursively
+        private static List<FieldInfo> GetAllFields(Type type, BindingFlags flags)
+        {
+            if (type == null)
+                return new List<FieldInfo>();
+
+            var list = GetAllFields( type.BaseType, flags );
+            
+            // In order to avoid duplicates, force BindingFlags.DeclaredOnly
+            list.AddRange( type.GetFields( flags | BindingFlags.DeclaredOnly ) );
+            return list;
+        }
+
+        // Get filtered variables for a type
+        private VariableGetterHolder[] GetFilteredVariablesForType( Type type )
 		{
 			VariableGetterHolder[] result;
 			if( typeToVariables.TryGetValue( type, out result ) )
@@ -1890,8 +1903,8 @@ namespace AssetUsageDetectorNamespace
 			// Filter the fields
 			if( fieldModifiers != BindingFlags.Instance )
 			{
-				FieldInfo[] fields = type.GetFields( fieldModifiers );
-				for( int i = 0; i < fields.Length; i++ )
+                List<FieldInfo> fields = GetAllFields( type, fieldModifiers );
+				for( int i = 0; i < fields.Count; i++ )
 				{
 					// Skip obsolete fields
 					if( Attribute.IsDefined( fields[i], typeof( ObsoleteAttribute ) ) )
@@ -2032,8 +2045,8 @@ namespace AssetUsageDetectorNamespace
 					searchedTypesStack.Push( type );
 
 					HashSet<Type> searchedVariableTypes = new HashSet<Type>();
-					FieldInfo[] fields = type.GetFields( fieldModifiers );
-					for( int i = 0; i < fields.Length; i++ )
+                    List<FieldInfo> fields = GetAllFields( type, fieldModifiers);
+					for( int i = 0; i < fields.Count; i++ )
 					{
 						Type fieldType = fields[i].FieldType;
 						if( searchedVariableTypes.Contains( fieldType ) )


### PR DESCRIPTION
Hi!

Thanks for UnityAssetUsageDetector. It's a very useful piece of code.
UnityAssetUsageDetector wasn't detecting some references in my project, so I tried making some changes to improve what kind of references it can find. I basically changed 2 things:

* GetFilteredVariablesForType now retrieves all fields from base types recursively. (I'm pretty sure this is what you'd want in general)
* IsSerializable now returns true for any field marked with attribute UnityEngine.SerializeField.

With these two changes I am able to find references in Paradoxnotion Behavior Trees and FSMs. (a Unity editor extension)

Note that I have never used this feature on github before, so please give me some feedback if you think I could have done things differently.

Thanks,
Tim