### PR TITLE
Add compatibility with SpriteAtlas

### DIFF
--- a/Plugins/AssetUsageDetector/Editor/ObjectToSearch.cs
+++ b/Plugins/AssetUsageDetector/Editor/ObjectToSearch.cs
@@ -95,6 +95,41 @@ namespace AssetUsageDetectorNamespace
 					}
 				}
 
+#if UNITY_2017_1_OR_NEWER
+				// If is an Atlas use get sprites directly as GetSubAssets return the final texture{
+				if (target is UnityEngine.U2D.SpriteAtlas spriteAtlas)
+				{
+					// packable objects cannot be access by API, so we use reflection to access the field // GetSprite returns a copy of the sprite, no a original reference
+					SerializedObject so = new SerializedObject(spriteAtlas);
+					SerializedProperty packablesProp = so.FindProperty("m_EditorData.packables");
+					if (packablesProp != null && packablesProp.isArray) // security in case is changed in another Unity version
+					{
+						for (int i = 0; i < packablesProp.arraySize; i++)
+						{
+							SerializedProperty element = packablesProp.GetArrayElementAtIndex(i);
+							Object textureObjectRef = element.objectReferenceValue;
+							if (textureObjectRef != null)
+							{
+								// Textures have sprites, so we get reference to all.
+								Object[] textureObjects = AssetDatabase.LoadAllAssetsAtPath( AssetDatabase.GetAssetPath(textureObjectRef));
+								for( int j = 0; j < textureObjects.Length; j++ )
+								{	
+									Object asset = textureObjects[j];
+									if (currentSubAssets.Add(asset))
+										subAssets.Add(new SubAsset(asset, shouldSearchChildren ?? true));
+								}
+							}
+						}
+					}
+					else
+					{
+						Debug.LogError($"Doesn't found packables in {target.name}"); // If this is throw, the variable has change
+					}
+					
+					return;
+				}
+#endif
+
 				// Find sub-asset(s) of the asset (if any)
 				Object[] assets = AssetDatabase.LoadAllAssetsAtPath( AssetDatabase.GetAssetPath( target ) );
 				for( int i = 0; i < assets.Length; i++ )


### PR DESCRIPTION
Search sub-assets now works with Sprite Atlas. This means enabled search sub assets is going to search also references to sprites that are part of the SpriteAtlas