### PR TITLE
Fixed 6.6 nullref caused by getting the removed `GetPackedSprites` method

### DIFF
--- a/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
+++ b/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
@@ -183,7 +183,10 @@ namespace AssetUsageDetectorNamespace
 		private readonly Func<Object> lightmapSettingsGetter = (Func<Object>) Delegate.CreateDelegate( typeof( Func<Object> ), typeof( LightmapEditorSettings ).GetMethod( "GetLightmapSettings", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ) );
 		private readonly Func<Object> renderSettingsGetter = (Func<Object>) Delegate.CreateDelegate( typeof( Func<Object> ), typeof( RenderSettings ).GetMethod( "GetRenderSettings", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ) );
 		private readonly Func<Cubemap> defaultReflectionProbeGetter = (Func<Cubemap>) Delegate.CreateDelegate( typeof( Func<Cubemap> ), typeof( RenderSettings ).GetProperty( "defaultReflection", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ).GetGetMethod( true ) );
-
+		
+#if !UNITY_6000_6_OR_NEWER
+		internal static readonly Func<SpriteAtlas, Sprite[]> spriteAtlasPackedSpritesGetter = (Func<SpriteAtlas, Sprite[]>) Delegate.CreateDelegate( typeof( Func<SpriteAtlas, Sprite[]> ), typeof( SpriteAtlasExtensions ).GetMethod( "GetPackedSprites", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ) );
+#endif
 #if ASSET_USAGE_ADDRESSABLES
 		private readonly PropertyInfo assetReferenceSubObjectTypeGetter = 
 			typeof( AssetReference ).GetProperty( "SubObjectType", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance )
@@ -1820,7 +1823,11 @@ namespace AssetUsageDetectorNamespace
 			{
 				if( result is SpriteAtlas spriteAtlas)
 				{
+#if UNITY_6000_6_OR_NEWER
 					Sprite[] packedSprites = spriteAtlas.GetPackedSprites();
+#else
+					Sprite[] packedSprites = AssetUsageDetector.spriteAtlasPackedSpritesGetter( spriteAtlas );
+#endif
 					if( packedSprites != null )
 					{
 						for( int i = 0; i < packedSprites.Length; i++ )

--- a/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
+++ b/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
@@ -1826,7 +1826,7 @@ namespace AssetUsageDetectorNamespace
 #if UNITY_6000_6_OR_NEWER
 					Sprite[] packedSprites = spriteAtlas.GetPackedSprites();
 #else
-					Sprite[] packedSprites = AssetUsageDetector.spriteAtlasPackedSpritesGetter(spriteAtlas);
+					Sprite[] packedSprites = spriteAtlasPackedSpritesGetter(spriteAtlas);
 #endif
 					if( packedSprites != null )
 					{

--- a/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
+++ b/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
@@ -184,7 +184,6 @@ namespace AssetUsageDetectorNamespace
 		private readonly Func<Object> renderSettingsGetter = (Func<Object>) Delegate.CreateDelegate( typeof( Func<Object> ), typeof( RenderSettings ).GetMethod( "GetRenderSettings", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ) );
 		private readonly Func<Cubemap> defaultReflectionProbeGetter = (Func<Cubemap>) Delegate.CreateDelegate( typeof( Func<Cubemap> ), typeof( RenderSettings ).GetProperty( "defaultReflection", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ).GetGetMethod( true ) );
 
-		internal static readonly Func<SpriteAtlas, Sprite[]> spriteAtlasPackedSpritesGetter = (Func<SpriteAtlas, Sprite[]>) Delegate.CreateDelegate( typeof( Func<SpriteAtlas, Sprite[]> ), typeof( SpriteAtlasExtensions ).GetMethod( "GetPackedSprites", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static ) );
 #if ASSET_USAGE_ADDRESSABLES
 		private readonly PropertyInfo assetReferenceSubObjectTypeGetter = 
 			typeof( AssetReference ).GetProperty( "SubObjectType", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance )
@@ -1819,9 +1818,9 @@ namespace AssetUsageDetectorNamespace
 			string subObjectName = assetReference.SubObjectName;
 			if( !string.IsNullOrEmpty( subObjectName ) )
 			{
-				if( result is SpriteAtlas )
+				if( result is SpriteAtlas spriteAtlas)
 				{
-					Sprite[] packedSprites = spriteAtlasPackedSpritesGetter( (SpriteAtlas) result );
+					Sprite[] packedSprites = spriteAtlas.GetPackedSprites();
 					if( packedSprites != null )
 					{
 						for( int i = 0; i < packedSprites.Length; i++ )

--- a/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
+++ b/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs
@@ -1821,12 +1821,12 @@ namespace AssetUsageDetectorNamespace
 			string subObjectName = assetReference.SubObjectName;
 			if( !string.IsNullOrEmpty( subObjectName ) )
 			{
-				if( result is SpriteAtlas spriteAtlas)
+				if(result is SpriteAtlas spriteAtlas)
 				{
 #if UNITY_6000_6_OR_NEWER
 					Sprite[] packedSprites = spriteAtlas.GetPackedSprites();
 #else
-					Sprite[] packedSprites = AssetUsageDetector.spriteAtlasPackedSpritesGetter( spriteAtlas );
+					Sprite[] packedSprites = AssetUsageDetector.spriteAtlasPackedSpritesGetter(spriteAtlas);
 #endif
 					if( packedSprites != null )
 					{

--- a/Plugins/AssetUsageDetector/Editor/ObjectToSearch.cs
+++ b/Plugins/AssetUsageDetector/Editor/ObjectToSearch.cs
@@ -99,7 +99,11 @@ namespace AssetUsageDetectorNamespace
 				// Add Sprites of SpriteAtlases to the sub-assets list
 				if( target is SpriteAtlas spriteAtlas )
 				{
+#if UNITY_6000_6_OR_NEWER
 					Sprite[] packedSprites = spriteAtlas.GetPackedSprites();
+#else
+					Sprite[] packedSprites = AssetUsageDetector.spriteAtlasPackedSpritesGetter( spriteAtlas );
+#endif
 					if( packedSprites != null )
 					{
 						for( int i = 0; i < packedSprites.Length; i++ )

--- a/Plugins/AssetUsageDetector/Editor/ObjectToSearch.cs
+++ b/Plugins/AssetUsageDetector/Editor/ObjectToSearch.cs
@@ -99,7 +99,7 @@ namespace AssetUsageDetectorNamespace
 				// Add Sprites of SpriteAtlases to the sub-assets list
 				if( target is SpriteAtlas spriteAtlas )
 				{
-					Sprite[] packedSprites = AssetUsageDetector.spriteAtlasPackedSpritesGetter( spriteAtlas );
+					Sprite[] packedSprites = spriteAtlas.GetPackedSprites();
 					if( packedSprites != null )
 					{
 						for( int i = 0; i < packedSprites.Length; i++ )

--- a/Plugins/AssetUsageDetector/Editor/Utilities.cs
+++ b/Plugins/AssetUsageDetector/Editor/Utilities.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using Unity.Collections;
 using UnityEditor;
 using UnityEditor.SceneManagement;
+using UnityEditor.U2D;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.U2D;
 using Object = UnityEngine.Object;
 
 namespace AssetUsageDetectorNamespace
@@ -563,6 +565,73 @@ namespace AssetUsageDetectorNamespace
 			}
 
 			return false;
+		}
+		
+		public static Sprite[] GetPackedSprites(this SpriteAtlas spriteAtlas)
+		{
+			Object[] packables;
+        
+			SpriteAtlas masterAtlas = spriteAtlas.isVariant ? spriteAtlas.GetMasterAtlas() : null;
+        
+			if (masterAtlas != null)
+			{
+				packables = masterAtlas.GetPackables();
+			}
+			else
+			{
+				packables = spriteAtlas.GetPackables();
+			}
+
+			List<Sprite> sprites = new();
+
+			for (int i = 0; i < packables.Length; ++i)
+			{
+				Object packable = packables[i];
+				if (packable == null)
+					continue;
+            
+				if (packable is DefaultAsset folder)
+				{
+					string folderPath = AssetDatabase.GetAssetPath(folder);
+					string[] spriteGuids = AssetDatabase.FindAssets("t:Sprite", new[] { folderPath });
+					for (int j = 0; j < spriteGuids.Length; ++j)
+					{
+						string spritePath = AssetDatabase.GUIDToAssetPath(spriteGuids[j]);
+						Object[] assets = AssetDatabase.LoadAllAssetsAtPath(spritePath);
+                    
+						foreach (Object asset in assets)
+						{
+							if (asset is Sprite sprite)
+							{
+								sprites.Add(sprite);
+							}
+						}
+					}
+				}
+				else if (packable is Texture2D)
+				{
+					string texturePath = AssetDatabase.GetAssetPath(packable);
+					Object[] assets = AssetDatabase.LoadAllAssetsAtPath(texturePath);
+                
+					foreach (Object asset in assets)
+					{
+						if (asset is Sprite sprite)
+						{
+							sprites.Add(sprite);
+						}
+					}
+				}
+				else if (packable is Sprite sprite)
+				{
+					sprites.Add(sprite);
+				}
+				else
+				{
+					Debug.LogError("Packed is " + packable.GetType());
+				}
+			}
+			
+			return sprites.ToArray();
 		}
 	}
 }


### PR DESCRIPTION
Unity removed the private `SpriteAtlasExtensions.GetPackedSprites` method in Unity 6.6, so opening the asset detector window generates this nullref, rendering it unusable:
```
ArgumentNullException: Value cannot be null.
Parameter name: method
System.Delegate.CreateDelegate (System.Type type, System.Object firstArgument, System.Reflection.MethodInfo method, System.Boolean throwOnBindFailure, System.Boolean allowClosed) (at <c5ae8a4eeb824526b5df2932bc2395e0>:0)
System.Delegate.CreateDelegate (System.Type type, System.Reflection.MethodInfo method, System.Boolean throwOnBindFailure) (at <c5ae8a4eeb824526b5df2932bc2395e0>:0)
System.Delegate.CreateDelegate (System.Type type, System.Reflection.MethodInfo method) (at <c5ae8a4eeb824526b5df2932bc2395e0>:0)
AssetUsageDetectorNamespace.AssetUsageDetector..cctor () (at ./Library/PackageCache/com.yasirkula.assetusagedetector@69f7ee5a27fc/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorSearchFunctions.cs:187)
Rethrow as TypeInitializationException: The type initializer for 'AssetUsageDetectorNamespace.AssetUsageDetector' threw an exception.
AssetUsageDetectorNamespace.AssetUsageDetectorWindow..ctor () (at ./Library/PackageCache/com.yasirkula.assetusagedetector@69f7ee5a27fc/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorWindow.cs:49)
UnityEngine.ScriptableObject:CreateInstance()
AssetUsageDetectorNamespace.AssetUsageDetectorWindow:GetWindow(WindowFilter) (at ./Library/PackageCache/com.yasirkula.assetusagedetector@69f7ee5a27fc/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorWindow.cs:169)
AssetUsageDetectorNamespace.AssetUsageDetectorWindow:OpenActiveWindow() (at ./Library/PackageCache/com.yasirkula.assetusagedetector@69f7ee5a27fc/Plugins/AssetUsageDetector/Editor/AssetUsageDetectorWindow.cs:188)
```

I added new `GetPackedSprites` logic similar to the one in `SpriteAtlasReportUtility` in the Unity 2D Tooling package.
Differences between the two new and old behaviours:
- Old behaviour: doesn't count sub-assets if Sprite Atlas packing is set to `Enabled for builds` or `Disabled`.
- New behaviour: always counts the sub-assets, even if Sprite Atlas packing is set to `Disabled`.